### PR TITLE
Fix routing error behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ More installation details here: https://docs.sentry.io/clients/ruby/
 ## Sentry-cli
 To easily leverage Sentry's Releases and Commits features, install sentry-cli. Installation instructions here: https://docs.sentry.io/learn/cli/installation/
 
-
+## Notes on routing errors
+By default `raven-ruby` ignores `ActionController::RoutingError`. For the purpose of demonstrating the `Undefined Route Error`, ```config.excluded_exceptions = []``` was added to the Raven config in `application.rb`. This configuration changes the default behavior to allow routing errors to appear in Sentry.
 
 ## Deploy to Heroku
 Note: Download and install Heroku Toolbelt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-This app demonstrates how to include and configure Sentry-Raven into a Ruby on Rails application. 
+This app demonstrates how to include and configure Sentry-Raven into a Ruby on Rails application.
 
 
 ## Prerequites  
@@ -13,25 +13,26 @@ This app demonstrates how to include and configure Sentry-Raven into a Ruby on R
 ## Setup Instructions
 1. Add Sentry-Raven gem to Gemfile
 
-```
+``` ruby
 gem "sentry-raven"
 ```
 
-2. Set the DSN in application.rb 
+2. Set the DSN in application.rb
 
-```
+``` ruby
 Raven.configure do |config|
   config.dsn = 'https://*******@sentry.io/22323232343'
 end
 ```
 
-3. Modify application_controller.rb 
-```
+3. Modify application_controller.rb
+
+``` ruby
 class ApplicationController < ActionController::Base
   before_action :set_raven_context
-  
-  private 
-  
+
+  private
+
   def set_raven_context
     Raven.user_context(id: session[:current_user_id]) # or anything else in session
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
@@ -58,6 +59,3 @@ heroku create
 ```
 git push herkou master
 ```
-
-
-

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,4 +20,5 @@ end
 
 Raven.configure do |config|
   config.dsn = 'https://*****:*****@sentry.io/258421'
+  config.excluded_exceptions = []
 end


### PR DESCRIPTION
By default `raven-ruby` excludes `ActionController::RoutingError`, so in the default configuration of this demo, Sentry won't catch the `Undefined Route Error`. By adding `config.excluded_exceptions = []`, that exclusion is removed and Sentry will catch the error.

Since this demo intends to show how Sentry interacts with a Ruby on Rails application, this PR adds that configuration so that routing errors are captured by default:

![demo-screenshot](https://github-slack.s3.amazonaws.com/monosnap/ActionControllerRoutingError_No_route_matches_GET_pagesundefined_route_error_2018-05-01_14-35-39.png)